### PR TITLE
HOTFIX/SYS-449 Fixed missing function "task_src"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
   when: users__enabled | bool
 
 - name: DebOps pre_tasks hook
-  include: "{{ lookup('task_src', 'users/pre_main.yml') }}"
+  include: users/pre_main.yml
 
 - include: users.yml
   when: users__enabled | bool
@@ -29,4 +29,4 @@
   tags: [ 'role::users:dotfiles' ]
 
 - name: DebOps post_tasks hook
-  include: "{{ lookup('task_src', 'users/post_main.yml') }}"
+  include: users/post_main.yml


### PR DESCRIPTION
This will fix this problem because the debops package is not updated anymore.
New people coming will face this problem until it PR got pushed.