### PR TITLE
Revert "HOTFIX/SYS-449 Fixed missing function "task_src""

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
   when: users__enabled | bool
 
 - name: DebOps pre_tasks hook
-  include: users/pre_main.yml
+  include: "{{ lookup('task_src', 'users/pre_main.yml') }}"
 
 - include: users.yml
   when: users__enabled | bool
@@ -29,4 +29,4 @@
   tags: [ 'role::users:dotfiles' ]
 
 - name: DebOps post_tasks hook
-  include: users/post_main.yml
+  include: "{{ lookup('task_src', 'users/post_main.yml') }}"


### PR DESCRIPTION
Reverts DevoInc/ansible-users#2

Sorry, my mistake, the problem here is that your ansible.cfg is not what we have in our repository. You have to use looks_plugin as you can see here:

https://github.com/debops/ansible-owncloud/issues/32